### PR TITLE
Fixes #6: Replace find-java-home with @viperproject/locate-java-home

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ A package that can be installed by `sdkmanager`.
 
 #### Defined in
 
-[index.ts:214](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L214)
+[index.ts:218](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L218)
 
 ___
 
@@ -377,7 +377,7 @@ The path to the installed tool's executable.
 
 #### Defined in
 
-[index.ts:336](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L336)
+[index.ts:340](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L340)
 
 ___
 
@@ -406,7 +406,7 @@ The path to the installed tool's executable.
 
 #### Defined in
 
-[index.ts:289](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L289)
+[index.ts:293](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L293)
 
 ___
 
@@ -431,7 +431,7 @@ The path to `$ANDROID_HOME` where the packages are installed.
 
 #### Defined in
 
-[index.ts:262](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L262)
+[index.ts:266](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L266)
 
 ___
 
@@ -449,7 +449,7 @@ An array of packages, each with their package path, version and description.
 
 #### Defined in
 
-[index.ts:233](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L233)
+[index.ts:237](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L237)
 
 ___
 
@@ -479,7 +479,7 @@ The result from execa, see: https://github.com/sindresorhus/execa#childprocess.
 
 #### Defined in
 
-[index.ts:405](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L405)
+[index.ts:409](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L409)
 
 ___
 
@@ -495,4 +495,4 @@ Update all installed packages to the latest version using `sdkmanager`.
 
 #### Defined in
 
-[index.ts:271](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L271)
+[index.ts:275](https://github.com/tweaselORG/andromatic/blob/main/src/index.ts#L275)

--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
     },
     "prettier": "@baltpeter/prettier-config",
     "dependencies": {
+        "@viperproject/locate-java-home": "^1.1.12",
         "cross-fetch": "^3.1.5",
         "decompress": "^4.2.1",
         "execa": "^7.1.1",
-        "find-java-home": "^2.0.0",
         "fs-extra": "^11.1.1",
         "global-cache-dir": "^4.4.0",
         "globby": "^13.1.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,11 +111,15 @@ export type AndroidToolName = keyof typeof versionedAndroidTools | keyof typeof 
  */
 export type AndroidTool = AndroidToolName | { tool: keyof typeof versionedAndroidTools; packageVersion: string };
 
-const ensureJavaHome = async (options?: { install?: boolean }): Promise<string> => {
-    const systemJavaHome = await findJavaHome({ allowJre: true });
-    if (systemJavaHome) return systemJavaHome;
+export { createEmulator } from './emulator';
+export type { EmulatorOptions } from './emulator';
 
+const ensureJavaHome = async (options?: { install?: boolean }): Promise<string> => {
     const javaVersion = 17;
+
+    const systemJavaHomes = await findJavaHome({ version: `>=${javaVersion}` });
+    if (systemJavaHomes?.[0]) return systemJavaHomes[0].path;
+
     const javaCacheDir = await globalCacheDir('andromatic-java');
 
     const existingBinaries = (
@@ -408,6 +412,3 @@ export const runAndroidDevTool = async (tool: AndroidTool, args?: string[], exec
     const toolPath = await getAndroidDevToolPath(tool);
     return execa(toolPath, args, { ...execaOptions, env: { ...env, ...execaOptions?.env } });
 };
-
-export { createEmulator } from './emulator';
-export type { EmulatorOptions } from './emulator';

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,10 @@
-import _findJavaHome from 'find-java-home';
+import locateJavaHomeModule from '@viperproject/locate-java-home/js/es6';
+import type { IJavaHomeInfo, ILocateJavaHomeOptions } from '@viperproject/locate-java-home/js/es6/lib/interfaces';
 import semverCoerce from 'semver/functions/coerce.js';
 import semverCompare from 'semver/functions/compare.js';
-import { promisify } from 'util';
+
+// For some reason the default export of locate-java-home is not set correctly, so we need to do this annoying little dance
+const locateJavaHome = (locateJavaHomeModule as unknown as { default: typeof locateJavaHomeModule }).default;
 
 export const getLatestVersion = (versions: string[], options?: { allowPrerelease?: boolean }) =>
     [...versions]
@@ -19,4 +22,11 @@ export const getLatestVersion = (versions: string[], options?: { allowPrerelease
         })
         .pop();
 
-export const findJavaHome = promisify(_findJavaHome) as (options?: { allowJre?: boolean }) => Promise<string>;
+export const findJavaHome = (options?: ILocateJavaHomeOptions) =>
+    new Promise<IJavaHomeInfo[] | undefined>((resolve, reject) => {
+        locateJavaHome(options || {}, (err, javaHomes) => {
+            if (err) return reject(err);
+
+            resolve(javaHomes?.sort((a, b) => semverCompare(a.version, b.version)));
+        });
+    });

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import locateJavaHomeModule from '@viperproject/locate-java-home/js/es6';
+import locateJavaHomeModule from '@viperproject/locate-java-home';
 import type { IJavaHomeInfo, ILocateJavaHomeOptions } from '@viperproject/locate-java-home/js/es6/lib/interfaces';
 import semverCoerce from 'semver/functions/coerce.js';
 import semverCompare from 'semver/functions/compare.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,6 @@
 {
     "extends": "@baltpeter/tsconfig",
     "include": ["src/**/*"],
-    "compilerOptions": {
-        "esModuleInterop": true
-    },
     "typedocOptions": {
         "plugin": ["typedoc-plugin-markdown"],
         "entryPoints": ["src/index.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
     "extends": "@baltpeter/tsconfig",
     "include": ["src/**/*"],
+    "compilerOptions": {
+        "esModuleInterop": true
+    },
     "typedocOptions": {
         "plugin": ["typedoc-plugin-markdown"],
         "entryPoints": ["src/index.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,6 +1029,14 @@
     "@typescript-eslint/types" "5.59.2"
     eslint-visitor-keys "^3.3.0"
 
+"@viperproject/locate-java-home@^1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@viperproject/locate-java-home/-/locate-java-home-1.1.12.tgz#78028c9839868135cc667dd8c743a61401863189"
+  integrity sha512-Rlvdp+k9aoiFD35UgLW41rgt66hcs1FacwZT/JxuW7PBcmDVpAyENN/AzETtIPcgQCl+cF4Xf4YFB/pQQsYmXQ==
+  dependencies:
+    async "^3.2.3"
+    semver "^7.3.5"
+
 abortcontroller-polyfill@^1.1.9:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz#6738495f4e901fbb57b6c0611d0c75f76c485bed"
@@ -1156,6 +1164,11 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
+async@^3.2.3:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 available-typed-arrays@^1.0.5:
   version "1.0.5"
@@ -2101,14 +2114,6 @@ find-java-home@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/find-java-home/-/find-java-home-1.2.2.tgz#8c5d82df57e48840da6625f61619026e4edafb0a"
   integrity sha512-rN2LcQa+YDwfnPT0TQgn015eYqJkn3h3G/uVX5oOD2Ge7gKOuoJrntAJO4BiGb+K6lo6Mb+xJdoqbfzqaC75gw==
-  dependencies:
-    which "~1.0.5"
-    winreg "~1.2.2"
-
-find-java-home@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/find-java-home/-/find-java-home-2.0.0.tgz#9073a14df6f74b951f4f7c2af88cf005bc059737"
-  integrity sha512-m4Cf5WM5Y9UupofsLgcJuY5oFXVfVnfHx43pg3HJoVdtY2PN4Wfs7ex9svf7W7eLTP+6wmyBToaqGOCffHBHVA==
   dependencies:
     which "~1.0.5"
     winreg "~1.2.2"
@@ -3822,6 +3827,13 @@ semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.5:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@^7.3.7, semver@^7.5.0:
   version "7.5.0"


### PR DESCRIPTION
Somehow the package of `locate-java-home` is broken and I already spent to much time trying to fix it. If you have any idea for a better fix, feel free.